### PR TITLE
D3 graph of calibrationValues.csv (x-errors only for now)

### DIFF
--- a/calibrationValuesGraph.html
+++ b/calibrationValuesGraph.html
@@ -11,22 +11,14 @@ Now you can open the graph of calibrationValues.csv at
 <meta charset="utf-8">
 <style>
 
-.axis--x path {
-  display: none;
-}
-
 .line {
   fill: none;
-  stroke: steelblue;
   stroke-width: 1.5px;
 }
 
 </style>
 <svg width="960" height="500"></svg>
-<script src="https://d3js.org/d3.v4.min.js"></script>
-<script src="https://d3js.org/d3-color.v1.min.js"></script>
-<script src="https://d3js.org/d3-interpolate.v1.min.js"></script>
-<script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
+<script src="https://d3js.org/d3.v5.min.js"></script>
 <script>
 
 var svg = d3.select("svg"),
@@ -38,17 +30,15 @@ var svg = d3.select("svg"),
 var x = d3.scaleLinear().range([0, width]),
     y = d3.scaleLinear().range([height, 0]),
     z = d3.scaleSequential(d3.interpolateBrBG);
-    // z = d3.scaleOrdinal(d3.schemeBrBG[11]);
 
 var line = d3.line()
     .curve(d3.curveBasis)
     .x(function(d) { return x(d.index); })
     .y(function(d) { return y(d.value); });
 
-d3.text("calibrationValues.csv", function(text) {
+d3.text("calibrationValues.csv").then(function(text) {
   var data = d3.csvParseRows(text).slice(0, 15).map(function(row) {
     return row.slice(0,31).map(function(d, i) {
-      // return +value;
       return {
         index: i-15,
         value: +d
@@ -70,7 +60,6 @@ d3.text("calibrationValues.csv", function(text) {
     .append("text")
       .attr("x", 37)
       .attr("y", -3)
-      // .attr("dy", "0.71em")
       .attr("fill", "#000")
       .text("Column index");
 

--- a/calibrationValuesGraph.html
+++ b/calibrationValuesGraph.html
@@ -1,0 +1,109 @@
+<!--
+D3 calibration graph. Run the following to start a simple python web server in this directory:
+
+    python -m SimpleHTTPServer 8888
+
+Now you can open the graph of calibrationValues.csv at
+
+    http://localhost:8888/calibrationValuesGraph.html
+ -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+
+.axis--x path {
+  display: none;
+}
+
+.line {
+  fill: none;
+  stroke: steelblue;
+  stroke-width: 1.5px;
+}
+
+</style>
+<svg width="960" height="500"></svg>
+<script src="https://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3-color.v1.min.js"></script>
+<script src="https://d3js.org/d3-interpolate.v1.min.js"></script>
+<script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
+<script>
+
+var svg = d3.select("svg"),
+    margin = {top: 20, right: 80, bottom: 30, left: 50},
+    width = svg.attr("width") - margin.left - margin.right,
+    height = svg.attr("height") - margin.top - margin.bottom,
+    g = svg.append("g").attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+var x = d3.scaleLinear().range([0, width]),
+    y = d3.scaleLinear().range([height, 0]),
+    z = d3.scaleSequential(d3.interpolateBrBG);
+    // z = d3.scaleOrdinal(d3.schemeBrBG[11]);
+
+var line = d3.line()
+    .curve(d3.curveBasis)
+    .x(function(d) { return x(d.index); })
+    .y(function(d) { return y(d.value); });
+
+d3.text("calibrationValues.csv", function(text) {
+  var data = d3.csvParseRows(text).slice(0, 15).map(function(row) {
+    return row.slice(0,31).map(function(d, i) {
+      // return +value;
+      return {
+        index: i-15,
+        value: +d
+      };
+    });
+  });
+
+  x.domain([-15, 15]);
+  y.domain([
+    d3.min(data, function(c) { return d3.min(c, function(d) { return d.value; }); }),
+    d3.max(data, function(c) { return d3.max(c, function(d) { return d.value; }); })
+  ]);
+  z.domain(data.map(function(c, i) { return i; }));
+
+  g.append("g")
+      .attr("class", "axis axis--x")
+      .attr("transform", "translate(0," + height + ")")
+      .call(d3.axisBottom(x))
+    .append("text")
+      .attr("x", 37)
+      .attr("y", -3)
+      // .attr("dy", "0.71em")
+      .attr("fill", "#000")
+      .text("Column index");
+
+
+  g.append("g")
+      .attr("class", "axis axis--y")
+      .call(d3.axisLeft(y))
+    .append("text")
+      .attr("transform", "rotate(-90)")
+      .attr("y", 6)
+      .attr("dy", "0.71em")
+      .attr("fill", "#000")
+      .text("Error (mm)");
+
+  var graphLine = g.selectAll(".graph-line")
+    .data(data)
+      .enter().append("g")
+      .attr("class", "graph-line");
+
+  graphLine.append("path")
+      .attr("class", "line")
+      .attr("d", function(d) { return line(d); })
+      .style("stroke", function(d, i) { return z(i/14); });
+
+  graphLine.append("text")
+      .attr("class", "line-label")
+      .datum(function(d, i) { return {id: i - 7, value: d[d.length - 1].value}; })
+      .attr("transform", function(d) { return "translate(" + (850 - ((d.id + 7) % 3) * 10) + "," + y(d.value) + ")"; })
+      .attr("x", 3)
+      .attr("dy", "0.35em")
+      .style("font", "10px sans-serif")
+      .style("stroke", function(d, i) { return z(i/14); })
+      .text(function(d) { return d.id; });
+});
+
+</script>


### PR DESCRIPTION
Generates a D3.js graph of calibrationValues.csv that looks like this:

![image](https://user-images.githubusercontent.com/218876/46913117-288b3800-cf3c-11e8-9f8f-a810e326939e.png)

The colors make it easy to track the way the different rows have errors across the board.

I'm hoping to use something like this to easily generate graphs from the simulator so that I can better understand how simulated errors affect calibration across the work area.

We can also easily overlay curve fit curves as well. It's all JavaScript so it could even be interactive if we get fancy.

We don't necessarily need to merge this in, but wanted to share in case it's useful.